### PR TITLE
Refactor: 카드 삭제 API 수정

### DIFF
--- a/src/main/java/talmo5/talmorello/card/entity/Card.java
+++ b/src/main/java/talmo5/talmorello/card/entity/Card.java
@@ -1,5 +1,6 @@
 package talmo5.talmorello.card.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -60,10 +61,10 @@ public class Card extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private talmo5.talmorello.column.entity.Column column;
 
-    @OneToMany(mappedBy = "card")
+    @OneToMany(mappedBy = "card", cascade = CascadeType.REMOVE)
     private Set<Comment> commentList;
 
-    @OneToMany(mappedBy = "card")
+    @OneToMany(mappedBy = "card", cascade = CascadeType.REMOVE)
     private Set<Todo> todoList;
 
     public void changeCardTitle(String cardTitle) {

--- a/src/main/java/talmo5/talmorello/card/repository/custom/CustomCardRepository.java
+++ b/src/main/java/talmo5/talmorello/card/repository/custom/CustomCardRepository.java
@@ -15,7 +15,7 @@ public interface CustomCardRepository {
 
     Optional<Board> getBoardByCardId(Long cardId);
 
-    void deleteCard(Card card, Column column);
+    void subtractCardOrdersToDeleteCard(Card card, Column column);
 
     void changeOrders(Long cardId, Long columnId, int newOrders, int oldOrders);
 

--- a/src/main/java/talmo5/talmorello/card/repository/custom/CustomCardRepositoryImpl.java
+++ b/src/main/java/talmo5/talmorello/card/repository/custom/CustomCardRepositoryImpl.java
@@ -79,18 +79,13 @@ public class CustomCardRepositoryImpl implements CustomCardRepository{
     }
 
     @Override
-    public void deleteCard(Card card, Column column) {
+    public void subtractCardOrdersToDeleteCard(Card card, Column column) {
 
         jpaQueryFactory
                 .update(QCard.card)
                 .set(QCard.card.orders, QCard.card.orders.subtract(1))
                 .where(QColumn.column.eq(column),
                         QCard.card.orders.gt(card.getOrders()))
-                .execute();
-
-        jpaQueryFactory
-                .delete(QCard.card)
-                .where(QCard.card.eq(card))
                 .execute();
 
         em.flush();

--- a/src/main/java/talmo5/talmorello/card/service/CardService.java
+++ b/src/main/java/talmo5/talmorello/card/service/CardService.java
@@ -223,7 +223,9 @@ public class CardService {
         boardUserValidator.validateBoardUser(board, user);
 
         cardUserRepository.deleteAllCardUserByCardId(card.getId());
-        cardRepository.deleteCard(card, card.getColumn());
+        cardRepository.subtractCardOrdersToDeleteCard(card, card.getColumn());
+
+        cardRepository.delete(card);
     }
 
     public Card findById(Long cardId) {

--- a/src/main/java/talmo5/talmorello/comment/entity/Comment.java
+++ b/src/main/java/talmo5/talmorello/comment/entity/Comment.java
@@ -13,8 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import talmo5.talmorello.auditing.BaseTime;
 import talmo5.talmorello.card.entity.Card;
 import talmo5.talmorello.user.entity.User;
@@ -34,7 +32,6 @@ public class Comment extends BaseTime {
     private String content;
 
     @JoinColumn(name = "card_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Card card;
 

--- a/src/main/java/talmo5/talmorello/todo/entity/Todo.java
+++ b/src/main/java/talmo5/talmorello/todo/entity/Todo.java
@@ -13,8 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import talmo5.talmorello.auditing.BaseTime;
 import talmo5.talmorello.card.entity.Card;
 import talmo5.talmorello.todo.constant.TodoStatus;
@@ -37,7 +35,6 @@ public class Todo extends BaseTime {
     private TodoStatus todoStatus;
 
     @JoinColumn(name = "card_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Card card;
 


### PR DESCRIPTION
cascade 옵션이 작동하게 하기 위해 카드 삭제 로직을 querydsl이 아닌 JpaRepository delete 메소드 사용